### PR TITLE
Update action.yaml

### DIFF
--- a/.github/workflows/actions/cleanup_runner/action.yaml
+++ b/.github/workflows/actions/cleanup_runner/action.yaml
@@ -15,7 +15,7 @@ runs:
       docker rmi $(docker image ls -q --filter "reference=node*")
       docker rmi $(docker image ls -q --filter "reference=debian*")
       docker rmi $(docker image ls -q --filter "reference=alpine*")
-      docker rmi $(docker image ls -q --filter "reference=ubuntu:18.04")
+      docker rmi $(docker image ls -q --filter "reference=ubuntu:22.04")
       docker rmi $(docker image ls -q --filter "reference=ubuntu:20.04")
       sudo apt purge \
         ansible \


### PR DESCRIPTION
[Official runner image removed ubuntu 18.04](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/) so I replace ubuntu 18.04 to ubuntu 22.04